### PR TITLE
Release 1.8

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,6 +7,7 @@ en:
     sift_notify_user: 'Enable User Notification When Post Is Filtered'
     sift_post_stay_visible: 'Posts stay visible until moderated'
     sift_use_standard_queue: 'Use the Discourse Flag queue for moderation instead of Community Sift queue'
+    sift_extra_flag_users: 'An extra flag will be added for each user in this comma separated list'
     sift_use_async_check: 'If true then classification is done using the Job queue, else classification is done at time of posting'
     sift_general_deny_level: 'General posts over this level will be auto denied'
     sift_bullying_deny_level: 'Bullying and Name Calling posts over this level will be auto denied'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,9 @@ plugins:
   sift_use_async_check:
     default: false
     shadowed_by_global: true
+  sift_extra_flag_users:
+    default: ''
+    shadowed_by_global: true
   sift_general_deny_level:
     default: '8'
     min: '0'

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,8 +1,9 @@
 # name: discourse-sift
 # about: supports content classifying of posts to Community Sift
-# version: 0.1.7
+# version: 0.1.8
 # authors: Richard Kellar, George Thomson
 # url: https://github.com/sift/discourse-sift
+
 
 enabled_site_setting :sift_enabled
 


### PR DESCRIPTION
Added option "sift_extra_flag_users" that will action posts as those users in addition to the system user.  This is a workaround for having a flag threshold for posts to show in the moderation queue