### PR TITLE
ENG-1318 error flagging user twice

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,6 +9,7 @@ en:
     sift_use_standard_queue: 'Use the Discourse Flag queue for moderation instead of Community Sift queue'
     sift_extra_flag_users: 'An extra flag will be added for each user in this comma separated list'
     sift_use_async_check: 'If true then classification is done using the Job queue, else classification is done at time of posting'
+    sift_error_is_false_response: 'If true then an error in the response from Coummunity Sift is treated as a false classification response'
     sift_general_deny_level: 'General posts over this level will be auto denied'
     sift_bullying_deny_level: 'Bullying and Name Calling posts over this level will be auto denied'
     sift_fighting_deny_level: 'Fighting posts over this level will be auto denied'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,9 @@ plugins:
   sift_extra_flag_users:
     default: ''
     shadowed_by_global: true
+  sift_error_is_false_response:
+    default: false
+    shadowed_by_global: true
   sift_general_deny_level:
     default: '8'
     min: '0'

--- a/lib/sift.rb
+++ b/lib/sift.rb
@@ -155,7 +155,7 @@ class Sift
           #   topics, and edits just to Title of topic also pass the post here
           # TODO: Should title be classified separately rather than pre-pending
           #   to the post text?
-          if to_classify.post_number == 1
+          if to_classify.is_first_post?
             request_text = "#{to_classify.topic.title} #{request_text}"
           end
 

--- a/lib/sift.rb
+++ b/lib/sift.rb
@@ -90,9 +90,19 @@ class Sift
           if response.nil? || response.status != 200
             #if there is an error reaching Community Sift, escalate to human moderation
 
+            Rails.logger.error("sift_debug: Got an error from Sift: status: #{response.status} response: #{response.inspect}")
+
+            # Setting determines if the response is treated as a
+            # classification failure
+            if SiteSetting.sift_error_is_false_response
+              classification_answer = false
+            else
+              classification_answer = true
+            end
+            
             data = {
               'risk' => 0,
-              'response' => false,
+              'response' => classification_answer,
               'topics' => {}
             }.to_json
             response = Excon::Response.new(:body => data)


### PR DESCRIPTION
Editing a post would blindly try to add flag(s) again and cause a `PostAction::AlreadyActed` exception.  Now a check on active flags is made for each flag to be added.

Also added:
- Plugin setting to determine if a failed request to Community Sift (i.e. a non-200 response) is marked as failed classification.  Previously it would always mark as a failed classification