### PR TITLE
Migrate old Sift reviews

### DIFF
--- a/lib/tasks/reviewables.rake
+++ b/lib/tasks/reviewables.rake
@@ -1,0 +1,152 @@
+desc 'Migrate sift reviews to the new Reviewable API'
+task 'reviewables:migrate_sift_reviews' => :environment do
+  migrate_reviewables
+  migrate_creation_history
+  migrate_scores
+  migrate_resolution_history
+end
+
+def migrate_reviewables
+  reporter = Discourse.system_user
+  DB.exec <<~SQL
+    INSERT INTO reviewables(
+      type,
+      status,
+      created_by_id,
+      reviewable_by_moderator,
+      payload,
+      category_id,
+      topic_id,
+      potential_spam,
+      target_id,
+      target_type,
+      target_created_by_id,
+      created_at,
+      updated_at
+    )
+    SELECT
+      'ReviewableSiftPost',
+      CASE
+        WHEN pcf.value = 'confirmed_failed' THEN #{Reviewable.statuses[:approved]}
+        WHEN pcf.value = 'confirmed_passed' THEN #{Reviewable.statuses[:rejected]}
+        WHEN pcf.value = 'dismissed' THEN #{Reviewable.statuses[:ignored]}
+        ELSE #{Reviewable.statuses[:pending]}
+      END,
+      #{reporter.id},
+      TRUE,
+      json_build_object('post_cooked', p.cooked, 'sift', sift.value),
+      t.category_id,
+      p.topic_id,
+      TRUE,
+      pcf.post_id,
+      'Post',
+      p.user_id,
+      pcf.created_at,
+      pcf.updated_at
+    FROM post_custom_fields AS pcf
+    INNER JOIN posts AS p ON pcf.post_id = p.id
+    INNER JOIN topics AS t ON t.id = p.topic_id
+    INNER JOIN post_custom_fields AS sift ON sift.post_id = p.id AND sift.name = 'sift'
+    WHERE
+      pcf.name = 'SIFT_STATE' AND
+      pcf.value IN ('confirmed_failed', 'confirmed_passed', 'dismissed', 'requires_moderation')
+  SQL
+end
+
+def migrate_scores
+  DB.exec <<~SQL
+    INSERT INTO reviewable_scores (
+      reviewable_id,
+      user_id,
+      reviewable_score_type,
+      status,
+      score,
+      take_action_bonus,
+      created_at,
+      updated_at,
+      reviewed_by_id,
+      reviewed_at
+    )
+    SELECT
+      r.id,
+      r.created_by_id,
+      #{PostActionType.types[:inappropriate]},
+      CASE
+        WHEN r.status = 1 OR r.status = 4 THEN 1
+        ELSE r.status
+      END,
+      1.0 +
+      CASE
+        WHEN u.admin = TRUE OR u.moderator = TRUE THEN 5.0
+        ELSE u.trust_level
+      END +
+      CASE
+        WHEN (us.flags_agreed + us.flags_disagreed + us.flags_ignored) > 5
+        THEN (us.flags_agreed / (us.flags_agreed + us.flags_disagreed + us.flags_ignored)) * 5
+        ELSE 0.0
+      END +
+      CASE WHEN r.status <> 0 THEN 5.0 ELSE 0.0 END,
+      CASE WHEN r.status <> 0 THEN 5.0 ELSE 0.0 END,
+      r.created_at,
+      r.created_at,
+      uh.acting_user_id,
+      uh.created_at
+    FROM reviewables AS r
+    INNER JOIN users AS u ON r.created_by_id = u.id
+    LEFT JOIN user_stats AS us ON  us.user_id = u.id
+    LEFT JOIN user_histories AS uh ON uh.post_id = r.target_id AND
+      uh.custom_type IN ('confirmed_failed','confirmed_passed','dismissed')
+    WHERE r.type = 'ReviewableSiftPost'
+  SQL
+end
+
+def migrate_creation_history
+  DB.exec <<~SQL
+    INSERT INTO reviewable_histories (
+      reviewable_id,
+      reviewable_history_type,
+      status,
+      created_by_id,
+      created_at,
+      updated_at
+    )
+    SELECT
+      r.id,
+      #{ReviewableHistory.types[:created]},
+      #{Reviewable.statuses[:ignored]},
+      r.created_by_id,
+      r.created_at,
+      r.created_at
+    FROM reviewables AS r
+    WHERE r.type = 'ReviewableSiftPost'
+  SQL
+end
+
+def migrate_resolution_history
+  DB.exec <<~SQL
+    INSERT INTO reviewable_histories (
+      reviewable_id,
+      reviewable_history_type,
+      status,
+      created_by_id,
+      created_at,
+      updated_at
+    )
+    SELECT
+      r.id,
+      #{ReviewableHistory.types[:transitioned]},
+      CASE
+        WHEN uh.custom_type = 'confirmed_failed' THEN #{Reviewable.statuses[:approved]}
+        WHEN uh.custom_type = 'confirmed_passed' THEN #{Reviewable.statuses[:rejected]}
+        ELSE #{Reviewable.statuses[:ignored]}
+      END,
+      uh.acting_user_id,
+      r.updated_at,
+      r.updated_at
+    FROM reviewables AS r
+    INNER JOIN user_histories AS uh ON uh.post_id = r.target_id
+    WHERE
+      uh.custom_type IN ('confirmed_failed', 'confirmed_passed', 'dismissed') AND
+      r.type = 'ReviewableSiftPost'
+  SQL
+end

--- a/models/reviewable_sift_post.rb
+++ b/models/reviewable_sift_post.rb
@@ -36,12 +36,12 @@ class ReviewableSiftPost < Reviewable
     # It's possible the post was recovered already
     PostDestroyer.new(performed_by, post).recover if post.deleted_at
 
-    log_confirmation(performed_by, 'confirmed_passed')
+    log_confirmation performed_by, 'confirmed_passed'
     successful_transition :rejected, :disagreed
   end
 
   def perform_ignore(performed_by, _args)
-    log_confirmation(performed_by, 'dismissed')
+    log_confirmation performed_by, 'dismissed'
     successful_transition :ignored, :ignored
   end
 

--- a/spec/lib/tasks/reviewables_spec.rb
+++ b/spec/lib/tasks/reviewables_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+describe 'Reviewables rake tasks', if: defined?(Reviewable) do
+  before do
+    Rake::Task.clear
+    Discourse::Application.load_tasks
+  end
+
+  describe '#migrate_sift_reviews' do
+    let(:post) { Fabricate(:post) }
+
+    before do
+      @sift_response = { response: false, topics: { "10" => 3 } }
+      post.custom_fields[DiscourseSift::RESPONSE_CUSTOM_FIELD] = @sift_response
+      post.save_custom_fields(true)
+    end
+
+    %w[pass_policy_guide auto_moderated].each do |state|
+      it "Does not migrate post that were tagged as #{state}" do
+        DiscourseSift.move_to_state(post, state)
+
+        run_migration
+        created_reviewables = ReviewableSiftPost.count
+
+        expect(created_reviewables).to be_zero
+      end
+    end
+
+    let(:admin) { Fabricate(:admin) }
+    let(:system_user) { Discourse.system_user }
+
+    %w[confirmed_failed confirmed_passed dismissed].each do |state|
+      it "Migrates posts that were tagged as #{state}" do
+        DiscourseSift.move_to_state(post, state)
+        log_action(admin, post, state)
+        actions_to_perform = 2
+
+        run_migration
+        reviewable = ReviewableSiftPost.includes(:reviewable_histories).last
+        reviewable_participants = reviewable.reviewable_histories.pluck(:created_by_id)
+
+        assert_review_was_created_correctly(reviewable, state)
+        expect(reviewable_participants).to eq [system_user.id, admin.id]
+      end
+    end
+
+    it 'Migrates posts needing review and leaves them ready to be reviewed with the new API' do
+      state = 'requires_moderation'
+      DiscourseSift.move_to_state(post, state)
+      actions_to_perform = 1
+
+      run_migration
+      reviewable = ReviewableSiftPost.includes(:reviewable_histories).last
+      reviewable_participants = reviewable.reviewable_histories.pluck(:created_by_id)
+
+      assert_review_was_created_correctly(reviewable, state)
+      expect(reviewable_participants).to eq [system_user.id]
+    end
+
+    def assert_review_was_created_correctly(reviewable, state)
+      expect(reviewable.status).to eq reviewable_status_for(state)
+      expect(reviewable.target_id).to eq post.id
+      expect(reviewable.topic_id).to eq post.topic_id
+      expect(reviewable.reviewable_by_moderator).to eq true
+      expect(reviewable.payload['post_cooked']).to eq post.cooked
+      expect(reviewable.payload['sift']).to eq @sift_response.to_json
+    end
+
+    describe 'Migrating scores' do
+      let(:innapropiate_type) { PostActionType.types[:inappropriate] }
+      let(:type_bonus) { PostActionType.where(id: innapropiate_type).pluck(:score_bonus)[0] }
+
+      it 'Creates a pending score for pending reviews' do
+        state = 'requires_moderation'
+        DiscourseSift.move_to_state(post, state)
+
+        run_migration
+        reviewable = ReviewableSiftPost.includes(:reviewable_scores).last
+        score = reviewable.reviewable_scores.last
+
+        assert_score_was_create_correctly(score, reviewable, state)
+        expect(score.reviewed_by).to be_nil
+        expect(score.take_action_bonus).to be_zero
+        expect(score.score).to eq ReviewableScore.user_flag_score(reviewable.created_by) + type_bonus
+      end
+
+      %w[dismissed confirmed_failed confirmed_passed].each do |state|
+        it "Creates an score with take action bonus when migrating a review with state: #{state} " do
+          expected_bonus = 5.0
+          DiscourseSift.move_to_state(post, state)
+          log_action(admin, post, state)
+
+          run_migration
+          reviewable = ReviewableSiftPost.includes(:reviewable_scores).last
+          score = reviewable.reviewable_scores.last
+
+          assert_score_was_create_correctly(score, reviewable, state)
+          expect(score.reviewed_by).to eq admin
+          expect(score.take_action_bonus).to eq expected_bonus
+          expect(score.score).to eq ReviewableScore.user_flag_score(reviewable.created_by) + type_bonus + expected_bonus
+        end
+      end
+
+      def assert_score_was_create_correctly(score, reviewable, action)
+        expect(score.user).to eq reviewable.created_by
+        expect(score.status).to eq score_status_for(action)
+        expect(score.reviewable_score_type).to eq innapropiate_type
+        expect(score.created_at).to eq reviewable.created_at
+      end
+
+      def score_status_for(action)
+        case action
+        when 'requires_moderation'
+          ReviewableScore.statuses[:pending]
+        when 'dismissed'
+          ReviewableScore.statuses[:ignored]
+        when 'confirmed_failed'
+          ReviewableScore.statuses[:agreed]
+        else
+          ReviewableScore.statuses[:disagreed]
+        end
+      end
+    end
+
+    def reviewable_status_for(state)
+      reviewable_states = Reviewable.statuses
+      case state
+      when 'confirmed_failed'
+        reviewable_states[:approved]
+      when 'confirmed_passed'
+        reviewable_states[:rejected]
+      when 'dismissed'
+        reviewable_states[:ignored]
+      else
+        reviewable_states[:pending]
+      end
+    end
+
+    def log_action(admin, post, state)
+      StaffActionLogger.new(admin).log_custom(state,
+        post_id: post.id, topic_id: post.topic_id
+      )
+    end
+
+    def run_migration
+      Rake::Task['reviewables:migrate_sift_reviews'].invoke
+    end
+  end
+end


### PR DESCRIPTION
This PR exposes a rake task to create `ReviewableSiftPost`s from existing reviews.

- Pending moderation reviews are migrated to pending reviewables.
- Already reviewed posts are migrated to the reviewables with equivalent status.
- Score and history are created/migrated (see tests).

This PR is a continuation of #31 and the task can be found in the last commit.