### PR TITLE
Feature/eng 2348 displaying badges only for risk4 and higher

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/flagged-post-below-controls/sift-flag-queue.hbs
+++ b/assets/javascripts/discourse/templates/connectors/flagged-post-below-controls/sift-flag-queue.hbs
@@ -3,10 +3,13 @@
 
     <div>
     {{#each-in flaggedPost.custom_fields.sift.topics as |topicKey topicValue|}}
+        <!-- following code line is a custom 'if' condition check via a helper to evaluate if the topicValue -->
+        {{#if (ifCond topicValue '>' 4)}}
       <span class="sift-topic sift-topic-risk-{{topicValue}}">
         <span class="sift-topic-{{topicKey}}"></span>
         <span class="sift-risk">{{topicValue}}</span>
       </span>
+        {{/if}}
     {{/each-in}}
     </div>
 

--- a/assets/javascripts/discourse/templates/connectors/flagged-post-below-controls/sift-flag-queue.hbs
+++ b/assets/javascripts/discourse/templates/connectors/flagged-post-below-controls/sift-flag-queue.hbs
@@ -4,7 +4,7 @@
     <div>
     {{#each-in flaggedPost.custom_fields.sift.topics as |topicKey topicValue|}}
         <!-- following code line is a custom 'if' condition check via a helper to evaluate if the topicValue -->
-        {{#if (ifCond topicValue '>' 4)}}
+        {{#if (ifCond topicValue '>=' 4)}}
       <span class="sift-topic sift-topic-risk-{{topicValue}}">
         <span class="sift-topic-{{topicKey}}"></span>
         <span class="sift-risk">{{topicValue}}</span>

--- a/assets/javascripts/helpers/ifCond.js.es6
+++ b/assets/javascripts/helpers/ifCond.js.es6
@@ -9,7 +9,7 @@ registerHelper('ifCond', function(params) {
     let operator = params[1];
     let boundaryRiskLevel = parseInt(params[2]);
     if (operator === '>='){
-        if (topicValue > boundaryRiskLevel) {
+        if (topicValue >= boundaryRiskLevel) {
             topicValueIsGreaterThanTheBoundaryRiskLevel =  true;
         }
     }

--- a/assets/javascripts/helpers/ifCond.js.es6
+++ b/assets/javascripts/helpers/ifCond.js.es6
@@ -1,0 +1,17 @@
+//This helper class is performing a greater than operation on given two values and returning True or False
+// based on the evaluation
+import { registerHelper } from 'discourse-common/lib/helpers';
+
+
+registerHelper('ifCond', function(params) {
+    let topicValueIsGreaterThanTheBoundaryRiskLevel = false;
+    let topicValue = params[0];
+    let operator = params[1];
+    let boundaryRiskLevel = params[2];
+    if (operator === '>'){
+        if (topicValue > boundaryRiskLevel) {
+            topicValueIsGreaterThanTheBoundaryRiskLevel =  true;
+        }
+    }
+    return topicValueIsGreaterThanTheBoundaryRiskLevel;
+});

--- a/assets/javascripts/helpers/ifCond.js.es6
+++ b/assets/javascripts/helpers/ifCond.js.es6
@@ -5,10 +5,10 @@ import { registerHelper } from 'discourse-common/lib/helpers';
 
 registerHelper('ifCond', function(params) {
     let topicValueIsGreaterThanTheBoundaryRiskLevel = false;
-    let topicValue = params[0];
+    let topicValue = parseInt(params[0]);
     let operator = params[1];
-    let boundaryRiskLevel = params[2];
-    if (operator === '>'){
+    let boundaryRiskLevel = parseInt(params[2]);
+    if (operator === '>='){
         if (topicValue > boundaryRiskLevel) {
             topicValueIsGreaterThanTheBoundaryRiskLevel =  true;
         }


### PR DESCRIPTION
Added a helper that would evaluate if the topicValue of the Risk badge is greater than the boundary value (4 in this case) and if so, the risk badge will be displayed