### PR TITLE
ENG-2631 Adding the language code of the settings to the mod_action payload if it is available, if not, setting the *

### DIFF
--- a/lib/sift.rb
+++ b/lib/sift.rb
@@ -137,6 +137,11 @@ class Sift
           'content_id' => "#{post.id}",
           'subcategory' => "#{post.topic&.id}"
       }
+      if !SiteSetting.sift_language_code.blank?
+        payload['language'] = SiteSetting.sift_language_code
+      else
+        payload['language'] = "*"
+      end
 
       Rails.logger.debug("sift_debug: payload = #{payload}")
 


### PR DESCRIPTION
Added the language code in the plugin settings page to the payload sent to the "sift_action_endpoint". Will be changing the workflow in Sift side to consume the "*". 