### PR TITLE
FIX: add post action for sift flagging

### DIFF
--- a/lib/discourse_sift.rb
+++ b/lib/discourse_sift.rb
@@ -136,6 +136,11 @@ module DiscourseSift
 
     if reviewable_api_enabled?
 
+      post_action = PostAction.active.flags.where(post: post, user: user)
+      if post_action.blank?
+        PostAction.create(user_id: user.id, post_id: post.id, post_action_type_id: PostActionType.types[:inappropriate], staff_took_action: false)
+        post.publish_change_to_clients! :acted
+      end
       ReviewableFlaggedPost.needs_review!(
         created_by: user,
         target: post,


### PR DESCRIPTION
Allows the agree with flag post actions to fire by creating a post action for the reviewable if none exist.