### PR TITLE
update plugin to 0.2.2 to match release version

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-sift
 # about: supports content classifying of posts to Community Sift
-# version: 0.2.0
+# version: 0.2.2
 # authors: Richard Kellar, George Thomson
 # url: https://github.com/sift/discourse-sift
 


### PR DESCRIPTION
This commit 8da8a7d5b386191d81507207e5d2fa4c0aecdfcc states this is now version 0.2.2, so we need to update this version number so that it is reflected in Discourse on the plugins page.