### PR TITLE
do not classify a post when it is deleted and has no topic

### DIFF
--- a/lib/discourse_sift.rb
+++ b/lib/discourse_sift.rb
@@ -8,6 +8,9 @@ module DiscourseSift
   def self.should_classify_post?(post)
     return false if post.blank? || (!SiteSetting.sift_enabled?)
 
+    # Don't classify if a post is orphaned
+    return false unless post.topic
+
     #Don't Classify Private Messages
     return false if post.topic.private_message?
 


### PR DESCRIPTION
Do not classify post if the post does not have a topic. This can happen in rare instances where the post gets deleted before it gets queued for classification.