### PR TITLE
FIX: Initializer was removed

### DIFF
--- a/assets/javascripts/discourse/initializers/add-sift-count.js.es6
+++ b/assets/javascripts/discourse/initializers/add-sift-count.js.es6
@@ -22,7 +22,6 @@ function subscribeToReviewCount(messageBus, user) {
 
 export default {
   name: 'add-sift-count',
-  before: 'register-discourse-location',
   after: 'inject-objects',
 
   initialize(container) {


### PR DESCRIPTION
The plugin will not work in the latest versions of Discourse without this patch.
